### PR TITLE
Fix assignment operator not being tested. Fixes #40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+Please see the **Tag Convention** section in the README.md for information on how to decode the tag meaning.
+
+## a3.2 - 2016-11-04
+### Fixed
+- Fix assignment operator not being tested in all tasks (#40)
+- Fix warning about comparing string literals
+
+## a3.1 - 2016-11-03
+### Added
+- Test cases using `insert()` and `get()` for Task 1
+
+## a3.0
+- Initial release
+
+## p8.0
+- Initial release

--- a/README.md
+++ b/README.md
@@ -23,3 +23,20 @@ A pull request will be opened for each practical before being merged into master
 The PR will be used for reporting results as the tests are being developed.
 
 If you find any problems with the test cases, please open a new issue.
+
+## Tag Convention
+- `AX.Y`
+    - `A` - a letter to indicate whether it is a practical or assignment
+    - `X` - a number to indicate the practical/assignment numnber
+- Example `a3.2`
+    - Assignment 3, Revision 2
+- Start at `AX.0` for initial test case release and increment Y for every change introduced into master
+
+### Multiple projects at the same time in master
+
+Example: We currently have assignment 3 and prac 8 in master
+- When prac 8 was merged it was tagged with `p8.0`
+- Assignment 3 was tagged with `a3.0` when it was merged
+- When we fix something in assignment 3, we only modify content in the assignment3 folder. We then tag the new merge with `a3.1`
+- This still allows us to have a single master, with multiple projects
+at independent versions

--- a/assignment3/task1.cpp
+++ b/assignment3/task1.cpp
@@ -285,7 +285,7 @@ TEST_CASE("testing linkedList<int> assignment operator", "[task1]") {
   LinkedList<int> *ll2 = new LinkedList<int>();
   ll2->insert(0, 9);
 
-  ll2 = ll1;
+  *ll2 = *ll1;
 
   ostringstream result;
   result << "[1,2,3]";

--- a/assignment3/task2.cpp
+++ b/assignment3/task2.cpp
@@ -348,7 +348,7 @@ TEST_CASE("testing CircularList<int> assignment operator", "[task2]") {
   CircularList<int> *ll2 = new CircularList<int>();
   ll2->insert(0, 9);
 
-  ll2 = ll1;
+  *ll2 = *ll1;
 
   ostringstream result;
   result << "[1,2,3]";
@@ -627,7 +627,9 @@ SCENARIO("SLL Tests") {
         try {
           list.insert(5, 'a');
         } catch (const char *e) {
-          REQUIRE(e == "invalid index");
+            string msg(e);
+
+          REQUIRE(msg == "invalid index");
         }
       }
 

--- a/assignment3/task3.cpp
+++ b/assignment3/task3.cpp
@@ -353,7 +353,7 @@ TEST_CASE("testing DoubleList<int> assignment operator", "[task3]") {
   DoubleList<int> *ll2 = new DoubleList<int>();
   ll2->insert(0, 9);
 
-  ll2 = ll1;
+  *ll2 = *ll1;
 
   ostringstream result;
   result << "[1,2,3]";
@@ -638,7 +638,9 @@ SCENARIO("SLL Tests") {
         try {
           list.insert(5, 'a');
         } catch (const char *e) {
-          REQUIRE(e == "invalid index");
+            string msg(e);
+
+          REQUIRE(msg == "invalid index");
         }
       }
 


### PR DESCRIPTION
The code for the assignment operator was not being compiled since it was never used by Black Fitch.

- Fix assignment(=) operator not being tested in Tasks 1 and 2 (#40)
- Fix warning about comparing string literals
