### PR TITLE
Remove -std=c++11 flag from task 3 compiler args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 Please see the **Tag Convention** section in the README.md for information on how to decode the tag meaning.
 
+## a3.3 - 2016-11-06
+### Changed
+- Remove `-std=c++11` flag when compiling task 3 to match Fitchfork
+
 ## a3.2 - 2016-11-04
 ### Fixed
 - Fix assignment operator not being tested in all tasks (#40)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Black Fitch  
 ===========
-![Latest Assignment Version](https://img.shields.io/badge/Assignment-3.2-green.svg)
+![Latest Assignment Version](https://img.shields.io/badge/Assignment-3.3-green.svg)
 ![Latest Practical Version](https://img.shields.io/badge/Practical-8.0-blue.svg)
 
 Unit tests for fitchfork practicals and assignments.

--- a/assignment3/makefile_template
+++ b/assignment3/makefile_template
@@ -2,6 +2,7 @@
 # 	black_fitch_path=/path/to/black-fitch/prac5
 
 compile=g++ -std=c++11 -Wall -pedantic -g -I "$(PWD)"
+compile_task3=g++ -Wall -pedantic -g -I "$(PWD)"
 
 # Always need:
 #	"$(black_fitch_path)/../catch/catchConfig.cpp"
@@ -20,7 +21,7 @@ task2:
 	./task2.out
 
 task3:
-	$(compile) $(task3_tests) -o task3.out
+	$(compile_task3) $(task3_tests) -o task3.out
 	./task3.out
 
 clean:


### PR DESCRIPTION
Fitchfork is not compiling Task 3 with `-std=c++11`:
```
Compile WARNING => Possible compile warnings and/or errors follow, try to get rid of them.
In file included from doubleList.h:116:0,
                 from dListTest.cpp:2:
doubleList.cpp: In copy constructor 'DoubleList<T>::DoubleList(const DoubleList<T>&)':
doubleList.cpp:15:71: warning: delegating constructors only available with -std=c++11 or -std=gnu++11
 DoubleList<T>::DoubleList(const DoubleList<T>& other) : DoubleList<T>(){
                                                                                                                    ^
```
## a3.3
### Changed
- Remove `-std=c++11` flag when compiling task 3 to match Fitchfork